### PR TITLE
fix: Navigation bar 플레이리스트 메뉴 및 CSS 수정

### DIFF
--- a/src/components/layout/NavMenuList.jsx
+++ b/src/components/layout/NavMenuList.jsx
@@ -17,14 +17,19 @@ const MenuContainer = styled.div`
   font-weight: 500;
   border-radius: 8px;
 
-  &.list-clicked {
+  &:hover {
+    background: var(--gray-bright-color);
+  }
+
+  &.list-default {
     background-color: none;
   }
 
   &.list-clicked {
-    background-color: #dcdde7;
-    color: var(--primary-color);
     font-weight: 600;
+    background: #dcdde7;
+    color: var(--primary-color);
+    transition: background 0.4s;
   }
 `;
 
@@ -35,12 +40,22 @@ const MenuType = {
   playlist: MusicAlt,
 };
 
-const NavMenuList = ({ menuType, menuText, onSelect, isSelected }) => {
+const NavMenuList = ({ menuType, menuText, onSelect, isSelected, playlistId }) => {
+  // 메뉴 타입에 맞는 아이콘 지정
   const Icon = MenuType[menuType];
 
+  const setSelectedMenu = () => {
+    if (menuType === 'playlist') {
+      // 메뉴 타입이 playlist인 경우, SelectedMenu를 menuType_playlistId로 지정
+      onSelect(menuType + '_' + playlistId);
+    } else {
+      // 메뉴 타입이 playlist가 아닌 경우, SelectedMenu를 menuType(기본)으로 지정
+      onSelect(menuType);
+    }
+  };
+
   return (
-    <MenuContainer onClick={() => onSelect(menuType)} className={isSelected ? 'list-clicked' : 'list-default'}>
-      <Home></Home>
+    <MenuContainer onClick={() => setSelectedMenu()} className={isSelected ? 'list-clicked' : 'list-default'}>
       <Icon fill={isSelected ? 'var(--primary-color)' : 'var(--gray-medium-color)'}></Icon>
       <div>{menuText}</div>
     </MenuContainer>

--- a/src/layouts/NavMenu.jsx
+++ b/src/layouts/NavMenu.jsx
@@ -30,16 +30,37 @@ const ListContainer = styled.div`
   gap: 12px;
 `;
 
-// const Menu = {
-//   home: {
-//     text: '홈',
-//     type: 'home',
-//   },
-//   playlists: {
-//     text: '플레이리스트',
-//     type: 'playlists',
-//   },
-// };
+// 내비게이션 메뉴 목록
+const Menu = [
+  {
+    text: '홈',
+    type: 'home',
+  },
+  {
+    text: '플레이리스트',
+    type: 'playlists',
+  },
+  {
+    text: '감정',
+    type: 'emotion',
+  },
+];
+
+// NOTE) playlist 더미 데이터, 수정 필요
+const Playlists = [
+  {
+    name: '코딩할 때 듣는 Lofi',
+    id: 1,
+  },
+  {
+    name: '드라이브엔 역시 시티팝',
+    id: 2,
+  },
+  {
+    name: '운동하면서 듣는 J-POP',
+    id: 3,
+  },
+];
 
 const NavMenu = () => {
   const [selectedMenu, setSelectedMenu] = useState(null);
@@ -54,15 +75,24 @@ const NavMenu = () => {
       <MenuContainer>
         <MenuTitle>메뉴</MenuTitle>
         <ListContainer>
-          <NavMenuList menuText={'홈'} menuType={'home'} onSelect={handleMenuClick} isSelected={selectedMenu === 'home'}></NavMenuList>
-          <NavMenuList menuText={'플레이리스트'} menuType={'playlists'} onSelect={handleMenuClick} isSelected={selectedMenu === 'playlists'}></NavMenuList>
-          <NavMenuList menuText={'감정'} menuType={'emotion'} onSelect={handleMenuClick} isSelected={selectedMenu === 'emotion'}></NavMenuList>
+          {Menu.map((item, index) => (
+            <NavMenuList key={index} menuText={item.text} menuType={item.type} onSelect={handleMenuClick} isSelected={selectedMenu === item.type}></NavMenuList>
+          ))}
         </ListContainer>
       </MenuContainer>
       <MenuContainer>
         <MenuTitle>플레이리스트</MenuTitle>
         <ListContainer>
-          <NavMenuList menuText={'코딩할 때 듣는 Lofi'} menuType={'playlist'} onSelect={handleMenuClick} isSelected={selectedMenu === 'playlist'}></NavMenuList>
+          {Playlists.map((item, index) => (
+            <NavMenuList
+              key={index}
+              menuText={item.name}
+              menuType={'playlist'}
+              onSelect={handleMenuClick}
+              isSelected={selectedMenu === `playlist_${item.id}`}
+              playlistId={item.id}
+            ></NavMenuList>
+          ))}
         </ListContainer>
       </MenuContainer>
     </Container>


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - [Notion-Ticket] : 
    - [Notion-API] : 

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - 좌측 내비게이션 바의 플레이리스트 메뉴가 1개만 클릭되도록 수정
    - 내비게이션 메뉴 hover, click 시 CSS에 duration 적용

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - 추후 내비게이션 바 내 플레이리스트 더미데이터 수정 필요
    - 내비게이션 메뉴에 Router 페이지네이션 로직 추가 필요 

> ## 📲&nbsp;&nbsp;마이그레이션 여부

    - [마이그레이션_APP] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No